### PR TITLE
Use the real NPM package version in the demo folder instead of the local library version

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "build": "npx tsc",
     "start": "node dist/index.js"
-    },
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.18.1"
+    "express": "^4.18.1",
+    "fast-file-converter": "^1.0.7"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/demo/src/index.ts
+++ b/demo/src/index.ts
@@ -32,7 +32,6 @@ app.get("/excel", (req: Request, res: Response) => {
   fastFile(data, "excel", res);
 });
 
-
 app.get("/csv", (req: Request, res: Response) => {
   let data = [
     { name: "john", age: 12 },
@@ -40,7 +39,6 @@ app.get("/csv", (req: Request, res: Response) => {
   ];
   fastFile(data, "csv", res);
 });
-
 
 app.get("/txt", (req: Request, res: Response) => {
   let data = [
@@ -58,7 +56,6 @@ app.get("/imSql", (req: Request, res: Response) => {
   fastFile(data, "imSql", res);
 });
 
-
 app.get("/json", (req: Request, res: Response) => {
   let data = [
     { name: "john", age: 12 },
@@ -70,4 +67,4 @@ const server = app.listen(port, () => {
   console.log(`⚡️[server]: Server is running at http://localhost:${port}`);
 });
 
-export default server;export default server;
+export default server;

--- a/demo/src/index.ts
+++ b/demo/src/index.ts
@@ -1,6 +1,6 @@
 import express, { Express, Request, Response } from "express";
 
-import fastFile from "../../dist/lib";
+import fastFile from "fast-file-converter";
 const app: Express = express();
 const port = 3000;
 
@@ -70,4 +70,4 @@ const server = app.listen(port, () => {
   console.log(`⚡️[server]: Server is running at http://localhost:${port}`);
 });
 
-export default server;
+export default server;export default server;


### PR DESCRIPTION
Hello ali ✋,
Good job with this really amazing package.

There was an issue that  came up to me when trying to clone the demo folder and run it for the very first time.
It was raising this error:
`Error: Cannot find module 'pdfmake`
In which i believe it's a dependency being used by the package itself.

The issue was that the demo folder is importing the local version of the the package in the root directory, in which it doesn't exists as people will try to only copy/clone the demo folder for quick use cases, so i believe it's a much better practice to have the real npm version of the package there instead of the local, and keeping it up to date.

Best.